### PR TITLE
Added indexOfTagAtPoint public method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ You can reload tags programmatically.
 - (void)reload;
 ```
 
+#### Index at point
+Returns the index of the tag located at the specified point.
+```
+- (NSInteger)indexOfTagAt:(CGPoint)point;
+```
+
 ### TTGTagCollectionView
 Use `TTGTagCollectionView` to show custom tag views.
 
@@ -307,6 +313,12 @@ Just like the UITableView, you must conform and implement the required methods o
 You can reload tags programmatically.
 ```
 - (void)reload;
+```
+
+#### Index at point
+Returns the index of the tag located at the specified point.
+```
+- (NSInteger)indexOfTagAt:(CGPoint)point;
 ```
 
 ## Fix

--- a/TTGTagCollectionView/Classes/TTGTagCollectionView.h
+++ b/TTGTagCollectionView/Classes/TTGTagCollectionView.h
@@ -95,4 +95,10 @@ typedef NS_ENUM(NSInteger, TTGTagCollectionAlignment) {
  */
 - (void)reload;
 
+/**
+ * Returns the index of the tag located at the specified point.
+ * If item at point is not found, returns NSNotFound.
+ */
+- (NSInteger)indexOfTagAt:(CGPoint)point;
+
 @end

--- a/TTGTagCollectionView/Classes/TTGTagCollectionView.m
+++ b/TTGTagCollectionView/Classes/TTGTagCollectionView.m
@@ -84,6 +84,19 @@
     [self invalidateIntrinsicContentSize];
 }
 
+- (NSInteger)indexOfTagAt:(CGPoint)point {
+    // We expect the point to be a point wrt to the TTGTagCollectionView.
+    // so convert this point first to a point wrt to the container view.
+    CGPoint convertedPoint = [self convertPoint:point toView:_containerView];
+    for (NSUInteger i = 0; i < [self.dataSource numberOfTagsInTagCollectionView:self]; i++) {
+        UIView *tagView = [self.dataSource tagCollectionView:self tagViewForIndex:i];
+        if (CGRectContainsPoint(tagView.frame, convertedPoint) && !tagView.isHidden) {
+            return i;
+        }
+    }
+    return NSNotFound;
+}
+
 #pragma mark - Gesture
 
 - (void)onTapGesture:(UITapGestureRecognizer *)tapGesture {

--- a/TTGTagCollectionView/Classes/TTGTextTagCollectionView.h
+++ b/TTGTagCollectionView/Classes/TTGTextTagCollectionView.h
@@ -155,4 +155,10 @@
 
 - (NSArray <NSString *> *)allNotSelectedTags;
 
+/**
+ * Returns the index of the tag located at the specified point.
+ * If item at point is not found, returns NSNotFound.
+ */
+- (NSInteger)indexOfTagAt:(CGPoint)point;
+
 @end

--- a/TTGTagCollectionView/Classes/TTGTextTagCollectionView.m
+++ b/TTGTagCollectionView/Classes/TTGTextTagCollectionView.m
@@ -391,6 +391,13 @@
     return [allTags copy];
 }
 
+- (NSInteger)indexOfTagAt:(CGPoint)point {
+    // We expect the point to be a point wrt to the TTGTextTagCollectionView.
+    // so convert this point first to a point wrt to the TTGTagCollectionView.
+    CGPoint convertedPoint = [self convertPoint:point toView:_tagCollectionView];
+    return [_tagCollectionView indexOfTagAt:convertedPoint];
+}
+
 #pragma mark - TTGTagCollectionViewDataSource
 
 - (NSUInteger)numberOfTagsInTagCollectionView:(TTGTagCollectionView *)tagCollectionView {


### PR DESCRIPTION
This method is similar to UITableView's `indexPathForRowAtPoint` method.
Useful for users who want to use their own gesture recognizers such as long press.