### PR TITLE
Allow User Interaction on tag's label

### DIFF
--- a/TTGTagCollectionView/Classes/TTGTextTagCollectionView.m
+++ b/TTGTagCollectionView/Classes/TTGTextTagCollectionView.m
@@ -720,6 +720,7 @@
 - (TTGTextTagLabel *)newLabelForTagText:(NSString *)tagText withConfig:(TTGTextTagConfig *)config {
     TTGTextTagLabel *label = [TTGTextTagLabel new];
     label.label.text = tagText;
+    label.label.userInteractionEnabled = YES;
     label.config = config;
     [self updateStyleAndFrameForLabel:label];
     return label;


### PR DESCRIPTION
UI tests are unable to tap the tag views via the accessibility identifier because the TTGTextTagLabel does not have an identifier - the gradient label within it does. However, the gradient label is currently not tappable. This change makes the label tappable so that UI tests can find the TTGTextTagLabel via the gradient label and tap it.