### PR TITLE
TTGTagCollectionAlignmentFillByExpandingWidthExceptLastLine模式下只有一行的时候防止item直接占满整行

### DIFF
--- a/TTGTagCollectionView/Classes/TTGTagCollectionView.m
+++ b/TTGTagCollectionView/Classes/TTGTagCollectionView.m
@@ -351,8 +351,8 @@
                 currentLineWidth = maxLineWidth;
                 
                 if (_alignment == TTGTagCollectionAlignmentFillByExpandingWidthExceptLastLine &&
-                    currentLine == numberOfLines - 1 &&
-                    numberOfLines != 1) {
+                    currentLine == numberOfLines - 1 /*&&
+                    numberOfLines != 1*/) {
                     // Reset last line width for TTGTagCollectionAlignmentFillByExpandingWidthExceptLastLine
                     currentLineAdditionWidth = 0;
                 }


### PR DESCRIPTION
TTGTagCollectionAlignmentFillByExpandingWidthExceptLastLine模式下只有一行的时候防止item直接占满整行